### PR TITLE
Crash fix and random warning fixes

### DIFF
--- a/encoders/smoothing.c
+++ b/encoders/smoothing.c
@@ -52,7 +52,7 @@ static void *start_smoothing( void *ptr )
         }
     }
 
-    int64_t send_delta = 0;
+    //int64_t send_delta = 0;
 
     while( 1 )
     {

--- a/filters/video/video.c
+++ b/filters/video/video.c
@@ -165,17 +165,6 @@ static int set_sar( obe_raw_frame_t *raw_frame, int is_wide )
     return -1;
 }
 
-static void scale_plane_c( uint16_t *src, int stride, int width, int height, int lshift, int rshift )
-{
-    for( int i = 0; i < height; i++ )
-    {
-        for( int j = 0; j < width; j++ )
-            src[j] = (src[j] << lshift) + (src[j] >> rshift);
-
-        src += stride / 2;
-    }
-}
-
 static void dither_row_10_to_8_c( uint16_t *src, uint8_t *dst, const uint16_t *dither, int width, int stride )
 {
     const int scale = 511;
@@ -278,33 +267,6 @@ static void blank_lines( obe_raw_frame_t *raw_frame )
     v = (uint16_t*)raw_frame->img.plane[2];
 
     blank_line( y, u, v, raw_frame->img.width / 2 );
-}
-
-static int scale_frame( obe_vid_filter_ctx_t *vfilt, obe_raw_frame_t *raw_frame )
-{
-    obe_image_t *img = &raw_frame->img;
-
-    /* TODO: when frames are needed for reference we can't scale in-place */
-
-    /* this function mimics how swscale does upconversion. 8-bit is converted
-     * to 16-bit through left shifting the orginal value with 8 and then adding
-     * the original value to that. This effectively keeps the full color range
-     * while also being fast. for n-bit we basically do the same thing, but we
-     * discard the lower 16-n bits. */
-    const int lshift = 16-obe_cli_csps[img->csp].bit_depth;
-    const int rshift = 2*obe_cli_csps[img->csp].bit_depth - 16;
-    for( int i = 0; i < img->planes; i++ )
-    {
-        uint16_t *src = (uint16_t*)img->plane[i];
-        int height = obe_cli_csps[img->csp].height[i] * img->height;
-        int width = obe_cli_csps[img->csp].width[i] * img->width;
-
-        vfilt->scale_plane( src, img->stride[i], width, height, lshift, rshift );
-    }
-
-    img->csp = img->csp == PIX_FMT_YUV420P ? PIX_FMT_YUV420P10 : PIX_FMT_YUV422P10;
-
-    return 0;
 }
 
 static int resize_frame( obe_vid_filter_ctx_t *vfilt, obe_raw_frame_t *raw_frame, int width )

--- a/filters/video/video.c
+++ b/filters/video/video.c
@@ -272,7 +272,6 @@ static void blank_lines( obe_raw_frame_t *raw_frame )
     /* All SDI input is 10-bit 4:2:2 */
     /* FIXME: assumes planar, non-interleaved format */
     uint16_t *y, *u, *v;
-    int cur_line = raw_frame->img.first_line;
 
     y = (uint16_t*)raw_frame->img.plane[0];
     u = (uint16_t*)raw_frame->img.plane[1];

--- a/input/sdi/decklink/decklink.cpp
+++ b/input/sdi/decklink/decklink.cpp
@@ -64,7 +64,7 @@ const static struct obe_to_decklink video_conn_tab[] =
     { INPUT_VIDEO_CONNECTION_COMPONENT,   bmdVideoConnectionComponent },
     { INPUT_VIDEO_CONNECTION_COMPOSITE,   bmdVideoConnectionComposite },
     { INPUT_VIDEO_CONNECTION_S_VIDEO,     bmdVideoConnectionSVideo },
-    { -1, -1 },
+    { -1, 0 },
 };
 
 const static struct obe_to_decklink audio_conn_tab[] =
@@ -72,7 +72,7 @@ const static struct obe_to_decklink audio_conn_tab[] =
     { INPUT_AUDIO_EMBEDDED,               bmdAudioConnectionEmbedded },
     { INPUT_AUDIO_AES_EBU,                bmdAudioConnectionAESEBU },
     { INPUT_AUDIO_ANALOGUE,               bmdAudioConnectionAnalog },
-    { -1, -1 },
+    { -1, 0 },
 };
 
 const static struct obe_to_decklink_video video_format_tab[] =
@@ -93,7 +93,7 @@ const static struct obe_to_decklink_video video_format_tab[] =
     { INPUT_VIDEO_FORMAT_1080P_50,        bmdModeHD1080p50,     1,    50 },
     { INPUT_VIDEO_FORMAT_1080P_5994,      bmdModeHD1080p5994,   1001, 60000 },
     { INPUT_VIDEO_FORMAT_1080P_60,        bmdModeHD1080p6000,   1,    60 },
-    { -1, -1, -1, -1 },
+    { -1, 0, -1, -1 },
 };
 
 class DeckLinkCaptureDelegate;

--- a/input/sdi/linsys/linsys.c
+++ b/input/sdi/linsys/linsys.c
@@ -212,7 +212,7 @@ struct linsys_status
 
 static inline void obe_decode_line( linsys_ctx_t *linsys_ctx, const uint32_t *src, uint16_t *y, uint16_t *u, uint16_t *v )
 {
-    uint32_t val;
+    uint32_t val = 0;
     int w;
 
     w = (linsys_ctx->width / 6) * 6;

--- a/input/sdi/sdi.c
+++ b/input/sdi/sdi.c
@@ -50,7 +50,7 @@ void obe_v210_planar_unpack_c( const uint32_t *src, uint16_t *y, uint16_t *u, ui
 void obe_v210_line_to_nv20_c( uint32_t *src, uint16_t *dst, int width )
 {
     int w;
-    uint32_t val;
+    uint32_t val = 0;
     uint16_t *uv = dst + width;
     for( w = 0; w < width - 5; w += 6 )
     {

--- a/mux/ts/ts.c
+++ b/mux/ts/ts.c
@@ -387,7 +387,6 @@ void *open_muxer( void *ptr )
     {
         video_found = 0;
         video_dts = 0;
-        int64_t lowest_pts = -1, largest_pts = -1;
 
         pthread_mutex_lock( &h->mux_queue.mutex );
 

--- a/obecli.c
+++ b/obecli.c
@@ -948,7 +948,6 @@ static int set_outputs( char *command, obecli_command_t *child )
         return -1;
 
     int tok_len = strcspn( command, " " );
-    int str_len = strlen( command );
     command[tok_len] = 0;
 
     num_outputs = obe_otoi( command, num_outputs );
@@ -973,7 +972,6 @@ static int set_output( char *command, obecli_command_t *child )
     {
         command += tok_len+1;
         int tok_len2 = strcspn( command, ":" );
-        int str_len2 = strlen( command );
         command[tok_len2] = 0;
         int output_id = obe_otoi( command, -1 );
         FAIL_IF_ERROR( output_id < 0 || output_id > cli.output.num_outputs-1, "Invalid output id\n" );

--- a/obecli.c
+++ b/obecli.c
@@ -329,11 +329,6 @@ static int obe_otoi( char *str, int def )
     return ret;
 }
 
-static char *obe_otos( char *str, char *def )
-{
-    return str ? str : def;
-}
-
 static int check_enum_value( const char *arg, const char * const *names )
 {
     for( int i = 0; names[i]; i++ )

--- a/output/ip/ip.c
+++ b/output/ip/ip.c
@@ -59,18 +59,6 @@ struct ip_status
     hnd_t *ip_handle;
 };
 
-static int64_t obe_gettime(void)
-{
-    struct timeval tv;
-    gettimeofday(&tv,NULL);
-    return (int64_t)tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
-static uint64_t obe_ntp_time(void)
-{
-  return (obe_gettime() / 1000) * 1000 + NTP_OFFSET_US;
-}
-
 static int rtp_open( hnd_t *p_handle, obe_udp_opts_t *udp_opts )
 {
     obe_rtp_ctx *p_rtp = calloc( 1, sizeof(*p_rtp) );
@@ -93,6 +81,18 @@ static int rtp_open( hnd_t *p_handle, obe_udp_opts_t *udp_opts )
     return 0;
 }
 #if 0
+static int64_t obe_gettime(void)
+{
+    struct timeval tv;
+    gettimeofday(&tv,NULL);
+    return (int64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+}
+
+static uint64_t obe_ntp_time(void)
+{
+  return (obe_gettime() / 1000) * 1000 + NTP_OFFSET_US;
+}
+
 static int write_rtcp_pkt( hnd_t handle )
 {
     obe_rtp_ctx *p_rtp = handle;


### PR DESCRIPTION
Somehow the crash on exit that I've fixed long time ago is again here.

Also included are three commits related to compiler warnings and also two commits that remove unused (possibly for now) functions.

With these fixes obe-rt builds without warnings on my system (excluding deprecated warnings from libav related to av_reverse and {get,reget,release}_buffer functions /those guys remove APIs just for the sake of it.../).
