### PR TITLE
Add support for command line parameters and reading commands from config file.

### DIFF
--- a/obecli.c
+++ b/obecli.c
@@ -1465,7 +1465,7 @@ static int parse_command( char *command, obecli_command_t *commmand_list )
     return 0;
 }
 
-int main( int argc, char **argv )
+static int run_cmd_prompt( void )
 {
     char *home_dir = getenv( "HOME" );
     char *history_filename;
@@ -1480,19 +1480,6 @@ int main( int argc, char **argv )
 
     sprintf( history_filename, "%s/.obecli_history", home_dir );
     read_history( history_filename );
-
-    cli.h = obe_setup();
-    if( !cli.h )
-    {
-        fprintf( stderr, "obe_setup failed\n" );
-        return -1;
-    }
-
-    cli.avc_profile = -1;
-
-    printf( "\nOpen Broadcast Encoder command line interface.\n" );
-    printf( "Version 1.0 \n" );
-    printf( "\n" );
 
     while( 1 )
     {
@@ -1518,17 +1505,6 @@ int main( int argc, char **argv )
             int ret = parse_command( line_read, main_commands );
             if( ret == -1 )
                 fprintf( stderr, "%s: command not found \n", line_read );
-
-            if( !cli.h )
-            {
-                cli.h = obe_setup();
-                if( !cli.h )
-                {
-                    fprintf( stderr, "obe_setup failed\n" );
-                    return -1;
-                }
-                cli.avc_profile = -1;
-            }
         }
     }
 
@@ -1538,4 +1514,23 @@ int main( int argc, char **argv )
     stop_encode( NULL, NULL );
 
     return 0;
+}
+
+int main( int argc, char **argv )
+{
+    printf( "\n" );
+    printf( "Open Broadcast Encoder command line interface.\n" );
+    printf( "Version 1.0\n" );
+    printf( "\n" );
+
+    cli.h = obe_setup();
+    if( !cli.h )
+    {
+        fprintf( stderr, "obe_setup failed\n" );
+        return -1;
+    }
+
+    cli.avc_profile = -1;
+
+    return run_cmd_prompt();
 }

--- a/obecli.c
+++ b/obecli.c
@@ -1573,12 +1573,13 @@ int run_with_config( void )
     return 0;
 }
 
-static const char short_options[] = "c:sh";
+static const char short_options[] = "c:shH";
 
 static const struct option long_options[] = {
     { "config-file",        required_argument, NULL, 'c' },
     { "shell",              no_argument,       NULL, 's' },
     { "help",               no_argument,       NULL, 'h' },
+    { "full-help",          no_argument,       NULL, 'H' },
     { 0, 0, 0, 0 }
 };
 
@@ -1591,7 +1592,15 @@ static void show_cmdline_params( void ) {
     printf("  -s --shell                 | Run interactive OBE shell. This is the default\n");
     printf("                             . action when no command line parameters are used.\n");
     printf("  -h --help                  | Show command line parameters.\n");
+    printf("  -H --full-help             | Show --help and show OBE configuration commands.\n");
     printf("\n");
+}
+
+static void show_cmd_help( char *in_cmd )
+{
+    char *cmd = strdup( in_cmd );
+    parse_command( cmd, main_commands );
+    free( cmd );
 }
 
 extern char *optarg;
@@ -1614,6 +1623,16 @@ int main( int argc, char **argv )
                 break;
             case 'h': // --help
                 show_cmdline_params();
+                return 0;
+            case 'H': // --full-help
+                show_cmdline_params();
+                show_cmd_help( "help ");
+                for( int i = 0; show_commands[i].name != 0; i++ )
+                {
+                    char show_cmd[32];
+                    snprintf( show_cmd, sizeof(show_cmd), "show %s", show_commands[i].name );
+                    show_cmd_help( show_cmd );
+                }
                 return 0;
         }
     }


### PR DESCRIPTION
Configuring obe using 'screen' hacks is not the best way for setting up the encoder, so I've added support for reading the commands from config file. This allows me to run obe using process supervision which is a nice thing (not that obe crashes but better safe than sorry).

Another small feature is --full-help parameter that lists what commands obe supports.
